### PR TITLE
Use TokIO Signal Handling for Shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,16 +1133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,7 +1181,6 @@ dependencies = [
  "openssl-sys",
  "reqwest",
  "serde_json",
- "signal-hook",
  "sysinfo",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ chrono = "0.4.37"
 env_logger = "0.11.3"
 log = "0.4.21"
 url = "2.5.0"
-signal-hook = "0.3.17"
 hyper = { version = "1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 http-body-util = "0.1"

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -2,14 +2,14 @@ use log::{info, warn};
 use std::error::Error;
 use std::sync::Arc;
 
-use signal_hook::consts::{SIGINT, SIGTERM};
-use signal_hook::iterator::Signals;
+use tokio::select;
+use tokio::signal::unix::{signal, SignalKind};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
 use crate::settings::Settings;
-use crate::{listener, monitor};
 use crate::storage::recorder;
+use crate::{listener, monitor};
 
 pub(crate) struct Launcher {
     threads: TaskTracker,
@@ -18,15 +18,18 @@ pub(crate) struct Launcher {
 
 impl Launcher {
     pub async fn listen_signals(&self) {
-        let context = self.context.clone();
-        let mut signals = Signals::new([SIGINT, SIGTERM]).unwrap();
+        let mut interrupt = signal(SignalKind::interrupt()).unwrap();
+        let mut terminate = signal(SignalKind::terminate()).unwrap();
         info!("Listening for termination signals.");
 
-        if signals.forever().next().is_some() {
-            warn!("Termination signal received. Shutting down.");
-            context.cancel();
-            self.threads.close();
+        select! {
+            _ = interrupt.recv() => {},
+            _ = terminate.recv() => {},
         }
+
+        warn!("Termination signal received. Shutting down.");
+        self.context.cancel();
+        self.threads.close();
     }
 }
 


### PR DESCRIPTION
Handle SIGINT and SIGTERM through Tokio's Unix signal streams so shutdown no longer depends on a blocking signal iterator. This keeps the runtime responsive when only one worker thread is available and removes the direct signal-hook dependency.